### PR TITLE
Use imported 'Hook' class in typescript example snippet

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -66,7 +66,7 @@ Custom events are just like lifecycle events, but you need to call `this.config.
 For example, you could define an analytics post function that you will run in your command. First define:
 
 **src/hooks/post_analytics.ts**
-```js
+```typescript
 import {Hook} from '@oclif/config'
 
 export default const hook: Hook<'post-analytics'> = async function (opts) {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -69,7 +69,7 @@ For example, you could define an analytics post function that you will run in yo
 ```js
 import {Hook} from '@oclif/config'
 
-export default const hook = async function (opts) {
+export default const hook: Hook<'post-analytics'> = async function (opts) {
   // code to post opts.id to analytics server
 }
 ```


### PR DESCRIPTION
The example snippet is listed as a TypeScript file (`src/hooks/post_analytics.ts`) and it imports the Hook class, but it never uses is.  This is confusing when reading the docs because it makes it seem like the import isn't needed and hooks are simply async functions magically known by their folder / file name location.

From looking at the other typescript example near the top of the same doc file it follows that `Hook` is a generic class that's intended to receive the hook name.  Based on the file name `post_analytics` I assume the hook would also be named `post-analytics`.

Questions:
- What is the conventional casing for hook names? (camel, ke-bab, snake)?
- Since Hook is generic class I believe what's in between the angle brackets such as `<'init'>` must be a Type so perhaps it's not allowed to be any random string, but a value from fixed set such as `'custom'`