### PR TITLE
Update base_class.md

### DIFF
--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -24,7 +24,7 @@ export default abstract class extends Command {
     }
   }
 
-  async init(err) {
+  async init() {
     // do some initialization
     const {flags} = this.parse(this.constructor)
     this.flags = flags


### PR DESCRIPTION
Using the example was throwing an error because `init` wasn't compatible with the base class method. Removing `err` fixes it.

I'm not sure about `finally`, maybe it should be updated too.