### PR TITLE
fix wrong comment for `cli.prompt('...', {type: 'hide'})`

### DIFF
--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -21,7 +21,7 @@ export class MyCommand extends Command {
     // mask input after enter is pressed
     const secondFactor = await cli.prompt('What is your two-factor token?', {type: 'mask'})
 
-    // mask input after enter is pressed
+    // mask input on keypress (before enter is pressed)
     const password = await cli.prompt('What is your password?', {type: 'hide'})
 
     this.log(`You entered: ${name}, ${secondFactor}, ${password}`)


### PR DESCRIPTION
taken from https://github.com/oclif/cli-ux#cliprompt

replaces #32