### PR TITLE
Fix typos

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ Inside a command, `this.config` provides useful properties you can use in your c
 * **pjson** - parsed and [normalized](https://github.com/npm/normalize-package-data) CLI `package.json`
 * **bin** - CLI bin name
 * **cacheDir** - CLI cache directory
-  * MacOS: `~/Library/Caches/mycli`
+  * macOS: `~/Library/Caches/mycli`
   * Unix: `~/.cache/mycli`
   * Windows: `%LOCALAPPDATA%\mycli`
   * Can be overridden with `XDG_CACHE_HOME`

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -8,7 +8,7 @@ There are a number of reasons why Node is the best choice for writing CLI code. 
 
 First, JavaScript is the biggest language in the world. More people are able to write JavaScript than any other language and it by far has the biggest open source community. Everyone can write it and you'll find the most helpful libraries to help build your CLI.
 
-We've found that Node has the best cross platform support of any language we've used. In general, if you write code on MacOS, you won't find many issues making it also run on Windows.
+We've found that Node has the best cross platform support of any language we've used. In general, if you write code on macOS, you won't find many issues making it also run on Windows.
 
 Node has the best support for our [plugins](plugins.md) model. Plugins are a way to share code between CLIs, to modularize a single CLIs codebase, or allow users to add functionality to an existing CLI. With Node, we're able to have separate dependency versions sitting alongside one another. This means if you want to release an update to a dependency in one plugin, it won't affect how another plugin works. oclif takes this to an extreme and even flag parsing is done at the individual plugin level. If we ever want to make a breaking change to flag parsing (we certainly don't intend to, but this is just an example), you can update just one plugin and keep the old behavior in other plugins. This is very helpful for large CLI codebases where you want to migrate to new code slowly.
 

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -26,14 +26,14 @@ For reference, here are the options and what they do:
 * **npm package name** the name of the package as it will be listed on npm.
 * **command bin name the CLI will export** the word the user will type to invoke the cli, e.g., “heroku” in the case of the Heroku command line interface. You may use any word here but be careful about using a word that may conflict with commonly used command line terms such as grep. In the case of conflict, the terminal will use what is loaded in the path sooner.
 * **description** this description is part of the npm package details. This description will stay local until you publish to npm
-* **author** The author is listed when you register your CLI on NPM
+* **author** The author is listed when you register your CLI on npm
 * **version** each time you publish a new version this number will automatically increment.
 * **license** MIT License is set as default
 * **node version supported** oclif supports [Active LTS Node versions](/docs/introduction#requirements)
-* **github owner of repository (https://github.com/OWNER/repo)** owner of the Github repo
-* **github name of repository (https://github.com/owner/REPO)** name of the Github repo
+* **github owner of repository (https://github.com/OWNER/repo)** owner of the GitHub repo
+* **github name of repository (https://github.com/owner/REPO)** name of the GitHub repo
 
-When your CLI is ready, you'll see a message ending with the following: 
+When your CLI is ready, you'll see a message ending with the following:
 
 ```
 Created mynewcli in /Users/nsamsami/mynewcli

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,9 +47,9 @@ In the Heroku CLI, we have it automatically build and release the beta channel o
 
 Build a windows installer with `oclif-dev pack:win`. It will build into `./dist/win`. This can be published to S3 with `oclif-dev publish:win`.
 
-## MacOS installer
+## macOS installer
 
-Build a MacOS .pkg installer with `oclif-dev pack:macos`. It will build into `./dist/macos`. This can be published to S3 with `oclif-dev publish:macos`. You need to set the MacOS identifier at `oclif.macos.identifier` in `package.json`. (For the Heroku CLI we use "com.heroku.cli" as the identifier)
+Build a macOS .pkg installer with `oclif-dev pack:macos`. It will build into `./dist/macos`. This can be published to S3 with `oclif-dev publish:macos`. You need to set the macOS identifier at `oclif.macos.identifier` in `package.json`. (For the Heroku CLI we use "com.heroku.cli" as the identifier)
 
 To [sign the installer](https://developer.apple.com/developer-id/), set `oclif.macos.sign` to a certificate (For the Heroku CLI this is "Developer ID Installer: Heroku INC"). And optionally set the keychain with `OSX_KEYCHAIN`.
 

--- a/docs/single.md
+++ b/docs/single.md
@@ -26,14 +26,14 @@ For reference, here are the options and what they do:
 * **npm package name** the name of the package as it will be listed on npm.
 * **command bin name the CLI will export** the word the user will type to invoke the cli, e.g., "heroku" in the case of the Heroku command line interface. You may use any word here but be careful about using a word that may conflict with commonly used command line terms such as grep. In the case of conflict, the terminal will use what is loaded in the path sooner.
 * **description** this description is part of the npm package details. This description will stay local until you publish to npm
-* **author** The author is listed when you register your CLI on NPM
+* **author** The author is listed when you register your CLI on npm
 * **version** each time you publish a new version this number will automatically increment.
 * **license** MIT License is set as default
 * **node version supported** oclif supports [Active LTS Node versions](/docs/introduction#requirements)
-* **github owner of repository (https://github.com/OWNER/repo)** owner of the Github repo
-* **github name of repository (https://github.com/owner/REPO)** name of the Github repo
+* **github owner of repository (https://github.com/OWNER/repo)** owner of the GitHub repo
+* **github name of repository (https://github.com/owner/REPO)** name of the GitHub repo
 
-When your CLI is ready, you'll see a message ending with the following: 
+When your CLI is ready, you'll see a message ending with the following:
 
 ```sh-session
 Created mynewcli in /Users/nsamsami/mynewcli

--- a/website/blog/2019-12-05-oclif-eslint-migration.md
+++ b/website/blog/2019-12-05-oclif-eslint-migration.md
@@ -10,7 +10,7 @@ Back in February of this year, plans were announced to [deprecate TSLint](https:
 
 To keep inline with the community, oclif has transitioned to ESLint for all our core libraries as well as all our official plugins.
 
-Starting in v1.15.x, oclif will now optionally generate projects with ESLint for both Typescript and JavaScript CLI’s.
+Starting in v1.15.x, oclif will now optionally generate projects with ESLint for both TypeScript and JavaScript CLI’s.
 
 ESLint does require Node to be on stable LTS version, at the time of writing, Node 8.10.x, Node 10.13.x & Node 12.x.x.
 


### PR DESCRIPTION
A few of typo fixes, e.g. `Github` -> `GitHub`, `Typescript` -> `TypeScript`, `MacOS` -> `macOS`