### PR TITLE
Docs clarifications

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,7 +35,7 @@ Your formula can be distributed through Brew. The main caveat is you must set th
 
 These tarballs as well as the installers below can be made autoupdatable by adding the `@oclif/plugin-update` plugin. Just add this plugin and the CLI will autoupdate in the background or when `mycli update` is run.
 
-If you don't want to use S3, you can still run `oclif-dev pack` and it will build tarballs. To get the updater to work, set `oclif.update.s3.host` to a host that has the files built in `./dist` from `oclif-dev pack`. This host does not need to be an S3 host. To customize the URL paths, see the S3 templates in `@oclif/config`.
+If you don't want to use S3, you can still run `oclif-dev pack` and it will build tarballs. To get the updater to work, set `oclif.update.s3.host` in `package.json` to a host that has the files built in `./dist` from `oclif-dev pack`. This host does not need to be an S3 host. To customize the URL paths, see the S3 templates in `@oclif/config`.
 
 ## Autoupdate Channels
 
@@ -51,7 +51,7 @@ Build a windows installer with `oclif-dev pack:win`. It will build into `./dist/
 
 Build a macOS .pkg installer with `oclif-dev pack:macos`. It will build into `./dist/macos`. This can be published to S3 with `oclif-dev publish:macos`. You need to set the macOS identifier at `oclif.macos.identifier` in `package.json`. (For the Heroku CLI we use "com.heroku.cli" as the identifier)
 
-To [sign the installer](https://developer.apple.com/developer-id/), set `oclif.macos.sign` to a certificate (For the Heroku CLI this is "Developer ID Installer: Heroku INC"). And optionally set the keychain with `OSX_KEYCHAIN`.
+To [sign the installer](https://developer.apple.com/developer-id/), set `oclif.macos.sign` in `package.json` to a certificate (For the Heroku CLI this is "Developer ID Installer: Heroku INC"). And optionally set the keychain with `OSX_KEYCHAIN`.
 
 ## Ubuntu/Debian packages
 

--- a/docs/running_programmatically.md
+++ b/docs/running_programmatically.md
@@ -51,7 +51,7 @@ export class HerokuRelease extends Command {
 **./src/display_config_vars.ts**
 
 ```typescript
-async function displayConfigVars(app: string) {
+export async function displayConfigVars(app: string) {
   const config = await api.get(`/apps/${app}config-vars`)
   for (let [key, value] of Object.entries(config)) {
     this.log(`${key}=${value}`)

--- a/docs/spinner.md
+++ b/docs/spinner.md
@@ -2,7 +2,7 @@
 title: Spinner
 ---
 
-[cli-ux](https://github.com/oclif/cli-ux) provides a simple `cli..action`, for more complex progress indicators we recommend using the [listr](https://www.npmjs.com/package/listr) library.
+[cli-ux](https://github.com/oclif/cli-ux) provides a simple `cli.action`, for more complex progress indicators we recommend using the [listr](https://www.npmjs.com/package/listr) library.
 
 ## `cli-ux.action`
 

--- a/docs/spinner.md
+++ b/docs/spinner.md
@@ -2,19 +2,28 @@
 title: Spinner
 ---
 
+[cli-ux](https://github.com/oclif/cli-ux) provides a simple `cli..action`, for more complex progress indicators we recommend using the [listr](https://www.npmjs.com/package/listr) library.
+
 ## `cli-ux.action`
 
 Shows a basic spinner
 
 ```typescript
-// start the spinner
-cli.action.start('starting a process')
-// show on stdout instead of stderr
-cli.action.start('starting a process', 'initializing', {stdout: true})
+import {Command} from '@oclif/command'
+import cli from 'cli-ux'
 
-// stop the spinner
-cli.action.stop() // shows 'starting a process... done'
-cli.action.stop('custom message') // shows 'starting a process... custom message'
+export class MyCommand extends Command {
+  async run() {
+    // start the spinner
+    cli.action.start('starting a process')
+    // show on stdout instead of stderr
+    cli.action.start('starting a process', 'initializing', {stdout: true})
+
+    // stop the spinner
+    cli.action.stop() // shows 'starting a process... done'
+    cli.action.stop('custom message') // shows 'starting a process... custom message'
+  }
+}
 ```
 
 This degrades gracefully when not connected to a TTY. It queues up any writes to stdout/stderr so they are displayed above the spinner.
@@ -23,6 +32,6 @@ This degrades gracefully when not connected to a TTY. It queues up any writes to
 
 ## listr
 
-Use [listr](https://www.npmjs.com/package/listr) for complex workflows like this:
+Here is an example of the complex workflows supported by [listr](https://www.npmjs.com/package/listr).
 
 ![listr demo](/img/listr.gif)

--- a/docs/spinner.md
+++ b/docs/spinner.md
@@ -16,11 +16,14 @@ export class MyCommand extends Command {
   async run() {
     // start the spinner
     cli.action.start('starting a process')
-    // show on stdout instead of stderr
-    cli.action.start('starting a process', 'initializing', {stdout: true})
-
+    // do some action...
     // stop the spinner
     cli.action.stop() // shows 'starting a process... done'
+    
+    // show on stdout instead of stderr
+    cli.action.start('starting a process', 'initializing', {stdout: true})    
+    // do some action...
+    // stop the spinner with a custom message
     cli.action.stop('custom message') // shows 'starting a process... custom message'
   }
 }


### PR DESCRIPTION
A few things I noticed while working through the docs:
- Had to search around a bit before I understood that "set `oclif.update.s3.host`" was setting in package.json. Now it's reiterated every time, and does not assume reading from start to finish
- In the shared code example, the shared code has to be exported
- The spinner documentation was missing necessary information on how to get `cli.action` to work. Found the info in the Prompting docs, and made the spinner docs match