### PR TITLE
Fix JS examples for custom help classes

### DIFF
--- a/docs/help_classes.md
+++ b/docs/help_classes.md
@@ -194,9 +194,9 @@ module.exports = class MyHelpClass extends HelpBase {
 ```
 
 ```js
-const {HelpBase} = require('@oclif/plugin-help');
+const Help = require('@oclif/plugin-help').default;
 
-module.exports = class MyHelpClass extends HelpBase {
+module.exports = class MyHelpClass extends Help {
   showHelp(args) {
   }
 


### PR DESCRIPTION
This fixes oclif/plugin-help#67.