### PR TITLE
Add return calls to base cmd error handling example

### DIFF
--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -30,10 +30,13 @@ export default abstract class extends Command {
     this.flags = flags
   }
   async catch(err) {
-    // handle any error from the command
+    // add any custom logic to handle errors from the command
+    // or simply return the parent class error handling
+    return super.catch(err);
   }
   async finally(err) {
     // called after run and catch regardless of whether or not the command errored
+    return super.finally(_);
   }
 }
 


### PR DESCRIPTION
Improve the docs for custom command base class.
Hope this helps other folks to not go through the same misunderstanding mentioned at https://github.com/oclif/oclif/issues/374