### PR TITLE
Fix export in docs/single.md

### DIFF
--- a/docs/single.md
+++ b/docs/single.md
@@ -80,11 +80,12 @@ Open `./src/index.ts` and replace it with the following
 
 ```js
 import {Command} from '@oclif/command'
-export class GoodbyeCommand extends Command {
+class GoodbyeCommand extends Command {
   async run() {
     console.log('goodbye, world!')
   }
 }
+export = GoodbyeCommand
 ```
 
 <!-- TODO: link to command API reference -->


### PR DESCRIPTION
Fix `TypeError: require(...).run is not a function`

```
.../bin/run:12
require(`../${dev ? 'src' : 'lib'}`).run()
                                     ^
TypeError: require(...).run is not a function
    at Object.<anonymous> (.../bin/run:12:38)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```