### PR TITLE
docs: fix hooks example export default const

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -11,9 +11,11 @@ A basic hook looks like the following in TypeScript:
 ```typescript
 import {Hook} from '@oclif/config'
 
-export default const hook: Hook<'init'> = async function (options) {
+const hook: Hook<'init'> = async function (options) {
   console.log(`example init hook running before ${options.id}`)
 }
+
+export default hook
 ```
 
 Or in JavaScript:
@@ -67,9 +69,11 @@ For example, you could define an analytics post function that you will run in yo
 **src/hooks/analytics/post.ts**
 
 ```typescript
-export default const hook = async function (options: {id: string}) {
+const hook = async function (options: {id: string}) {
   // code to post options.id to analytics server
 }
+
+export default hook
 ```
 
 **package.json**


### PR DESCRIPTION
Noticed some hooks examples in docs using `export default const`, which I'm not sure is a standard ES Modules syntax - refactoring to separate exports.