### PR TITLE
fix: send reader to correct usage example in Features - CLI Generator

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -16,7 +16,7 @@ The overhead for running an oclif CLI command is almost nothing. [It requires ve
 
 ### CLI Generator
 
-Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#-usage) below.
+Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](./introduction#quickstart) in the introduction quickstart.
 
 ### Testing Helpers
 


### PR DESCRIPTION
There's a broken link in the CLI Generator section from the Features page. It seems like it should point to the Quickstart's snippet from the Introduction page.