### PR TITLE
update dead link for CLI generator usage

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -16,7 +16,7 @@ The overhead for running an oclif CLI command is almost nothing. [It requires ve
 
 ### CLI Generator
 
-Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#-usage) below.
+Run a single command to scaffold out a fully functional CLI and get started quickly. See [Generator Commands](https://oclif.io/docs/generator_commands).
 
 ### Testing Helpers
 


### PR DESCRIPTION
On the Features page on the oclif docs -> https://oclif.io/docs/features , the link for Usages for CLI Generator goes nowhere; and no file/section called Usage exists. Shown below.
```
### CLI Generator

Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#-usage) below.
```

I'm simply updated the link to lead to https://oclif.io/docs/generator_commands

```
### CLI Generator

Run a single command to scaffold out a fully functional CLI and get started quickly. See [Generator Commands](https://oclif.io/docs/generator_commands).
```