### PR TITLE
Fixes the example for using a base class

### DIFF
--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -38,11 +38,15 @@ export default abstract class BaseCommand<T extends FlagInput<any>> extends Comm
     return this.processedFlags as Partial<OutputFlags<typeof BaseCommand.flags>>;
   }
 
-  log(msg: any, level: string) {
+  log(msg: any, level: string = 'info') {
     switch (this.baseFlags.loglevel) {
       case 'error':
         // eslint-disable-next-line no-console
         if (level === 'error') console.error(msg);
+        break;
+      case 'info':
+        // eslint-disable-next-line no-console
+        if (level === 'info') console.info(msg);
         break;
       // a complete example would need to have all the levels
     }
@@ -91,7 +95,7 @@ export default class MyCommand extends BaseCommand<typeof MyCommand.flags> {
   static args: ArgInput = [{ name: 'file' }];
 
   public async run(): Promise<void> {
-    console.log({
+    this.log({
       args: this.processedArgs,
       flags: this.processedFlags,
     });

--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -6,52 +6,106 @@ Use inheritance to share functionality between common commands. Here is an examp
 
 For large CLIs with multiple plugins, it's useful to put this base class into its own npm package to be shared.
 
-```js
-// src/base.ts
-import {Command, Flags} from '@oclif/core'
+### Inferred Flags Type
+This is needed to get type safety working in derived classes
+```ts
+// src/types/inferredFlagsType.ts
 
-export default abstract class extends Command {
+import { FlagInput } from '@oclif/core/lib/interfaces';
+
+export type InferredFlagsType<T> = T extends FlagInput<infer F>
+  ? F & {
+      json: boolean | undefined;
+    }
+  : any;
+```
+
+### Base Class:
+```ts
+// src/base.ts
+
+import { Command, Flags } from '@oclif/core';
+import { FlagInput, OutputFlags, ParserOutput } from '@oclif/core/lib/interfaces';
+import { InferredFlagsType } from './types/inferredFlagsType';
+
+export default abstract class BaseCommand<T extends FlagInput<any>> extends Command {
   static flags = {
-    loglevel: Flags.string({options: ['error', 'warn', 'info', 'debug']})
+    loglevel: Flags.string({ options: ['error', 'warn', 'info', 'debug'], default: 'log' }),
+  };
+
+  protected parsedOutput?: ParserOutput<any, any>;
+
+  get processedArgs(): { [name: string]: any } {
+    return this.parsedOutput?.args ?? {};
+  }
+  get processedFlags(): InferredFlagsType<T> {
+    return this.parsedOutput?.flags ?? {};
   }
 
-  log(msg, level) {
-    switch (this.flags.loglevel) {
-    case 'error':
-      if (level === 'error') console.error(msg)
-      break
-    // a complete example would need to have all the levels
+  private get baseFlags() {
+    return this.processedFlags as Partial<OutputFlags<typeof BaseCommand.flags>>;
+  }
+
+  log(msg: any, level: string) {
+    switch (this.baseFlags.loglevel) {
+      case 'error':
+        // eslint-disable-next-line no-console
+        if (level === 'error') console.error(msg);
+        break;
+      // a complete example would need to have all the levels
     }
   }
 
   async init() {
     // do some initialization
-    const {flags} = this.parse(this.constructor)
-    this.flags = flags
+    this.parsedOutput = await this.parse(this.ctor);
   }
-  async catch(err) {
+
+  async catch(err: any) {
     // add any custom logic to handle errors from the command
     // or simply return the parent class error handling
     return super.catch(err);
   }
-  async finally(err) {
+
+  async finally(err: any) {
     // called after run and catch regardless of whether or not the command errored
-    return super.finally(_);
+    return super.finally(err);
   }
 }
+```
 
-// src/commands/mycommand.ts
-import Command from '../base'
+### Derived class:
+```ts
+// src/commands/myCommand.ts
 
-export class MyCommand extends Command {
+import { Flags } from '@oclif/core';
+import { ArgInput } from '@oclif/core/lib/interfaces';
+import BaseCommand from '../base';
+
+export default class MyCommand extends BaseCommand<typeof MyCommand.flags> {
+  static description = 'This is a derived command';
+
+  static examples = ['<%= config.bin %> <%= command.id %>'];
+
   static flags = {
-    ...Command.flags,
-    extraflag: Flags.string()
-  }
+    ...BaseCommand.flags,
 
-  async run() {
-    this.log('information', 'info')
-    this.log('uh oh!', 'error')
+    // flag with a value (-n, --name=VALUE)
+    name: Flags.string({ char: 'n', description: 'name to print' }),
+    // flag with no value (-f, --force)
+    force: Flags.boolean({ char: 'f' }),
+  };
+
+  static args: ArgInput = [{ name: 'file' }];
+
+  public async run(): Promise<void> {
+    console.log({
+      args: this.processedArgs,
+      flags: this.processedFlags,
+    });
+
+    // We now get complete type safety on 'this.processedFlags'!!
+    console.log(this.processedFlags.force);
   }
 }
 ```

--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -6,27 +6,19 @@ Use inheritance to share functionality between common commands. Here is an examp
 
 For large CLIs with multiple plugins, it's useful to put this base class into its own npm package to be shared.
 
-### Inferred Flags Type
-This is needed to get type safety working in derived classes
-```ts
-// src/types/inferredFlagsType.ts
-
-import { FlagInput } from '@oclif/core/lib/interfaces';
-
-export type InferredFlagsType<T> = T extends FlagInput<infer F>
-  ? F & {
-      json: boolean | undefined;
-    }
-  : any;
-```
-
 ### Base Class:
 ```ts
 // src/base.ts
 
 import { Command, Flags } from '@oclif/core';
 import { FlagInput, OutputFlags, ParserOutput } from '@oclif/core/lib/interfaces';
-import { InferredFlagsType } from './types/inferredFlagsType';
+
+// This is needed to get type safety working in derived classes
+export type InferredFlagsType<T> = T extends FlagInput<infer F>
+  ? F & {
+      json: boolean | undefined;
+    }
+  : any;
 
 export default abstract class BaseCommand<T extends FlagInput<any>> extends Command {
   static flags = {

--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -20,7 +20,7 @@ export type InferredFlagsType<T> = T extends FlagInput<infer F>
     }
   : any;
 
-export default abstract class BaseCommand<T extends FlagInput<any>> extends Command {
+export default abstract class BaseCommand<T extends typeof BaseCommand.flags> extends Command {
   static flags = {
     loglevel: Flags.string({ options: ['error', 'warn', 'info', 'debug'], default: 'info' }),
   };

--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -22,7 +22,7 @@ export type InferredFlagsType<T> = T extends FlagInput<infer F>
 
 export default abstract class BaseCommand<T extends FlagInput<any>> extends Command {
   static flags = {
-    loglevel: Flags.string({ options: ['error', 'warn', 'info', 'debug'], default: 'log' }),
+    loglevel: Flags.string({ options: ['error', 'warn', 'info', 'debug'], default: 'info' }),
   };
 
   protected parsedOutput?: ParserOutput<any, any>;
@@ -97,7 +97,10 @@ export default class MyCommand extends BaseCommand<typeof MyCommand.flags> {
     });
 
     // We now get complete type safety on 'this.processedFlags'!!
-    console.log(this.processedFlags.force);
+    this.log(this.processedFlags.force, 'info');
+    
+    this.log('information', 'info');
+    this.log('uh oh!', 'error');
   }
 }
 ```


### PR DESCRIPTION
This is in response to the bugs as reported here: 
https://github.com/oclif/oclif/issues/577
https://github.com/oclif/oclif/issues/225

There already seems to be a proposed solution here: https://github.com/oclif/oclif.github.io/pull/118

But it does not seem to provide proper type safety in the derived classes.

So, here's a different take on using a base class with the help of Generics and a custom Type.