### PR TITLE
update: documentation - remove `private` from `enableJsonFlag` example

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -9,7 +9,7 @@ When this property is set and the user supplies the `--json` flag, the command w
 ```typescript
 import {Command} from '@oclif/core'
 export class HelloCommand extends Command {
-  private static enableJsonFlag = true
+  static enableJsonFlag = true
   public async run(): Promise<{ message: string }> {
     console.log('hello, world!')
     return { message: 'hello, world!' }


### PR DESCRIPTION
The example doesn't work as Command does not implement `enableJsonFlag` with private.

```shell
Class static side 'typeof HelloCommand' incorrectly extends base class static side 'typeof Command'.
  Property 'enableJsonFlag' is private in type 'typeof HelloCommand' but not in type 'typeof Command'.
```