### PR TITLE
Missing `await` before `this.parse(...)` in "Command Flags" docs

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -23,7 +23,7 @@ export class MyCLI extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(MyCLI)
+    const {flags} = await this.parse(MyCLI)
     if (flags.force) console.log('--force is set')
     if (flags.file) console.log(`--file is: ${flags.file}`)
   }
@@ -88,7 +88,7 @@ export class MyCLI extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(MyCLI)
+    const {flags} = await this.parse(MyCLI)
     if (flags.team) console.log(`--team is ${flags.team}`)
   }
 }


### PR DESCRIPTION
Copy-and-pasting the example in the latest version of oclif doesn't work b/c the `await` is missing and `this.parse(...)` returns a Promise.