### PR TITLE
Change link to "Build your own plugin" from Features to Plugins page

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@ By default you can pass `--help` to the CLI to get help such as flag options and
 
 ### Plugins
 
-Using plugins, users of the CLI can extend it with new functionality, a CLI can be split into modular components, and functionality can be shared amongst multiple CLIs. See [Building your own plugin](#-building-your-own-plugin) below.
+Using plugins, users of the CLI can extend it with new functionality, a CLI can be split into modular components, and functionality can be shared amongst multiple CLIs. See [Building your own plugin](https://oclif.io/docs/plugins#building-your-own-plugin).
 
 ### Hooks
 


### PR DESCRIPTION
The "Build your own plugin" has a broken link to the features page which no longer contains this section. 
Fixing this to point to the Plugins page instead, and removing "below" from the text as it is no longer true.
The link is formatted according to other links in this document.