### PR TITLE
Clarify Node.js LTS support

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -42,7 +42,7 @@ If you're using npx, install it first with `npm install -g oclif`. This won't st
 
 ## Why isn't Node X supported?
 
-The oclif project follows and supports [Node's Active LTS support schedule](https://nodejs.org/en/about/releases/). This allows oclif to stay current with Node's development.
+The oclif project follows and supports [Node's LTS support schedule](https://nodejs.org/en/about/releases/). This allows oclif to stay current with Node's development.
 
 ## How do I pronounce "oclif"?
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ Everything is customizable in oclif. Even the flag parser and help generation is
 
 ## Requirements
 
-Only [Active LTS Node versions](https://nodejs.org/en/about/releases/) are supported. You can add the [node](https://www.npmjs.com/package/node) package to your CLI to ensure users are on a specific Node version.
+Only [LTS Node versions](https://nodejs.org/en/about/releases/) are supported. You can add the [node](https://www.npmjs.com/package/node) package to your CLI to ensure users are on a specific Node version.
 
 
 ## Quickstart

--- a/website/blog/2021-03-01-introducing-oclif-core.md
+++ b/website/blog/2021-03-01-introducing-oclif-core.md
@@ -51,5 +51,5 @@ The oclif team
 | Utility CLIs | oclif@<2<br/>@oclif/dev-cli@<2 | oclif@>=2
 | Main packages | @oclif/core@<2<br/>@oclif/config@<2<br/>@oclif/errors@<2<br/>@oclif/parser@<4<br/>@oclif/plugin-help@<4<br/> | @oclif/core@>=1
 | Node LTS | Node v8-14 | Node v12+ |
-| Typescript | typescript@<4 | typescript@>=4 |
+| TypeScript | typescript@<4 | typescript@>=4 |
 | Main plugins | @oclif/plugin-autocomplete@<1<br/>@oclif/plugin-commands@<2<br/>@oclif/plugin-help@<4<br/>@oclif/plugin-not-found@<2<br/>@oclif/plugin-plugins@<2<br/>@oclif/plugin-update@<2<br/>plugin-warn-if-update-available@<2<br/>plugin-which@<2<br/> | @oclif/plugin-autocomplete@>=2<br/>@oclif/plugin-commands@>=2<br/>@oclif/plugin-help@>=4<br/>@oclif/plugin-not-found@>=2<br/>@oclif/plugin-plugins@>=2<br/>@oclif/plugin-update@>=2<br/>@oclif/plugin-warn-if-update-available@>=2<br/>@oclif/plugin-which@>=2<br/> |

--- a/website/blog/2022-01-12-announcing-oclif-v2.md
+++ b/website/blog/2022-01-12-announcing-oclif-v2.md
@@ -6,7 +6,7 @@ Hello and happy new year! It's our great pleasure to announce that we have relea
 
 oclif v2 includes many changes that improve the experience of both creating and using an oclif CLI.
 
-Going forward, we don't plan to make any updates to oclif v1 and its corresponding libraries, except for critical security fixes. See the [compatibility matrix](#compatibility-matrix) for a list of these libraries. In order to give developers time to migrate from v1 to v2, we're not completely dropping support yet. But at some point in the future we'll archive the v1 repositories and deprecate their versions on NPM.
+Going forward, we don't plan to make any updates to oclif v1 and its corresponding libraries, except for critical security fixes. See the [compatibility matrix](#compatibility-matrix) for a list of these libraries. In order to give developers time to migrate from v1 to v2, we're not completely dropping support yet. But at some point in the future we'll archive the v1 repositories and deprecate their versions on npm.
 
 ## What’s changing?
 
@@ -105,5 +105,5 @@ The following matrix shows how the v1 libraries and plugins relate to the new v2
 | Utility CLIs | oclif@<2<br/>@oclif/dev-cli@<2 | oclif@>=2
 | Main packages | @oclif/command<br/>@oclif/config<br/>@oclif/errors<br/>@oclif/parser<br/>@oclif/plugin-help<br/> | @oclif/core@>=1
 | Node LTS | Node v8-14 | Node v12+ (at time of writing) |
-| Typescript | typescript@<4 | typescript@>=4 |
+| TypeScript | typescript@<4 | typescript@>=4 |
 | Main plugins | @oclif/plugin-autocomplete@<1<br/>@oclif/plugin-commands@<2<br/>@oclif/plugin-help@<4<br/>@oclif/plugin-not-found@<2<br/>@oclif/plugin-plugins@<2<br/>@oclif/plugin-update@<2<br/>plugin-warn-if-update-available@<2<br/>plugin-which@<2<br/> | @oclif/plugin-autocomplete@>=1<br/>@oclif/plugin-commands@>=2<br/>@oclif/plugin-help@>=4<br/>@oclif/plugin-not-found@>=2<br/>@oclif/plugin-plugins@>=2<br/>@oclif/plugin-update@>=2<br/>@oclif/plugin-warn-if-update-available@>=2<br/>@oclif/plugin-which@>=2<br/> |


### PR DESCRIPTION
Just a minor clarification regarding support of Node's LTS versions. _Active LTS_ only refers to a **single** version, however support should (at least) **also include** the _Maintenance LTS_ version. Therefore, it is better to just generally refer to "LTS versions".

Also fixes a couple of minor typos that made their way into the repo since #70 was merged.