### PR TITLE
Awaiting this.parse(MyCLI) for the response

### DIFF
--- a/docs/args.md
+++ b/docs/args.md
@@ -15,7 +15,7 @@ export class MyCLI extends Command {
 
   async run() {
     // can get args as an object
-    const {args} = this.parse(MyCLI)
+    const {args} = await this.parse(MyCLI)
     console.log(`running my command with args: ${args.firstArg}, ${args.secondArg}`)
     // can also get the args as an array
     const {argv} = this.parse(MyCLI)


### PR DESCRIPTION
We have to await for the `this.parse(MyCLI)`.