### PR TITLE
fix(docs): await this.parse in all docs

### DIFF
--- a/docs/args.md
+++ b/docs/args.md
@@ -18,7 +18,7 @@ export class MyCLI extends Command {
     const {args} = await this.parse(MyCLI)
     console.log(`running my command with args: ${args.firstArg}, ${args.secondArg}`)
     // can also get the args as an array
-    const {argv} = this.parse(MyCLI)
+    const {argv} = await this.parse(MyCLI)
     console.log(`running my command with args: ${argv[0]}, ${argv[1]}`)
   }
 }

--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -26,7 +26,7 @@ export default abstract class extends Command {
 
   async init() {
     // do some initialization
-    const {flags} = this.parse(this.constructor)
+    const {flags} = await this.parse(this.constructor)
     this.flags = flags
   }
   async catch(err) {

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -46,7 +46,7 @@ export class MyCommand extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(MyCommand)
+    const {flags} = await this.parse(MyCommand)
     let stage = flags.stage
     if (!stage) {
       let responses: any = await inquirer.prompt([{

--- a/docs/running_programmatically.md
+++ b/docs/running_programmatically.md
@@ -19,7 +19,7 @@ export class HerokuConfig extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(HerokuConfig)
+    const {flags} = await this.parse(HerokuConfig)
     const config = await api.get(`/apps/${flags.app}/config-vars`)
     for (let [key, value] of Object.entries(config)) {
       this.log(`${key}=${value}`)
@@ -41,7 +41,7 @@ export class HerokuRelease extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(HerokuRelease)
+    const {flags} = await this.parse(HerokuRelease)
     await this.doRelease(flags.app)
     await displayConfigVars(flags.app)
   }
@@ -76,7 +76,7 @@ export class HerokuRelease extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(HerokuRelease)
+    const {flags} = await this.parse(HerokuRelease)
     await this.doRelease(flags.app)
     await HerokuConfig.run(['--app', flags.app])
   }

--- a/docs/table.md
+++ b/docs/table.md
@@ -74,7 +74,7 @@ export default class Users extends Command {
   }
 
   async run() {
-    const {flags} = this.parse(Users)
+    const {flags} = await this.parse(Users)
     const {data: users} = await axios.get('https://jsonplaceholder.typicode.com/users')
 
     CliUx.ux.table(users, {


### PR DESCRIPTION
Adds `await` to all the `this.parse()` statements in the docs to match the oclif v2.