### PR TITLE
fix: base class example

### DIFF
--- a/docs/base_class.md
+++ b/docs/base_class.md
@@ -2,56 +2,83 @@
 title: Custom Base Class
 ---
 
-Use inheritance to share functionality between common commands. Here is an example of a command base class that has some common shared flags and a log method that can be shared among many commands.
+Use inheritance to share functionality between common commands. Here is an example of a command base class that has some common shared flags.
 
 For large CLIs with multiple plugins, it's useful to put this base class into its own npm package to be shared.
 
-```js
-// src/base.ts
-import {Command, Flags} from '@oclif/core'
+```typescript
+// src/baseCommand.ts
+import {Command, Flags, Interfaces} from '@oclif/core'
 
-export default abstract class extends Command {
-  static flags = {
-    loglevel: Flags.string({options: ['error', 'warn', 'info', 'debug']})
+enum LogLevel {
+  debug = 'debug',
+  info = 'info',
+  warn = 'warn',
+  error = 'error',
+}
+
+export type Flags<T extends typeof Command> = Interfaces.InferredFlags<typeof BaseCommand['globalFlags'] & T['flags']>
+
+export abstract class BaseCommand<T extends typeof Command> extends Command {
+  // add the --json flag
+  static enableJsonFlag = true
+
+  // define flags that can be inherited by any command that extends BaseCommand
+  static globalFlags = {
+    'log-level': Flags.enum<LogLevel>({
+      summary: 'Specify level for logging.',
+      options: Object.values(LogLevel),
+      helpGroup: 'GLOBAL',
+    }),
   }
 
-  log(msg, level) {
-    switch (this.flags.loglevel) {
-    case 'error':
-      if (level === 'error') console.error(msg)
-      break
-    // a complete example would need to have all the levels
-    }
-  }
+  protected flags!: Flags<T>
 
-  async init() {
-    // do some initialization
-    const {flags} = await this.parse(this.constructor)
+  public async init(): Promise<void> {
+    await super.init()
+    const {flags} = await this.parse(this.constructor as Interfaces.Command.Class)
     this.flags = flags
   }
-  async catch(err) {
+
+  protected async catch(err: Error & {exitCode?: number}): Promise<any> {
     // add any custom logic to handle errors from the command
     // or simply return the parent class error handling
-    return super.catch(err);
+    return super.catch(err)
   }
-  async finally(err) {
+
+  protected async finally(_: Error | undefined): Promise<any> {
     // called after run and catch regardless of whether or not the command errored
-    return super.finally(_);
+    return super.finally(_)
   }
 }
 
-// src/commands/mycommand.ts
-import Command from '../base'
+// src/commands/my-command.ts
 
-export class MyCommand extends Command {
+export default class MyCommand extends BaseCommand<typeof MyCommand> {
+  static summary = 'child class that extends BaseCommand'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json',
+    '<%= config.bin %> <%= command.id %> --log-level debug',
+  ]
+
   static flags = {
-    ...Command.flags,
-    extraflag: Flags.string()
+    name: Flags.string({
+      char: 'n',
+      summary: 'Name to print.',
+      required: true,
+    }),
   }
 
-  async run() {
-    this.log('information', 'info')
-    this.log('uh oh!', 'error')
+  public async run(): Promise<Flags<typeof MyCommand>> {
+    for (const [flag, value] of Object.entries(this.flags)) {
+      this.log(`${flag}: ${value}`)
+    }
+
+    return this.flags
   }
 }
 ```
+
+For a more complex example, [here's](https://github.com/salesforcecli/sf-plugins-core/blob/main/src/sfCommand.ts) how we do this for the Salesforce CLI.


### PR DESCRIPTION
Fixes the example for a base command class to be compilable and type safe

Closes #142 
Closes https://github.com/oclif/oclif/issues/577