### PR TITLE
Working configuration of oclif with mocha tests

### DIFF
--- a/docs/esm.md
+++ b/docs/esm.md
@@ -71,3 +71,19 @@ oclif
   },
   ...
 }
+```
+
+5. Replace Content of `test/tsconfig.json` with the following: 
+
+```json
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "commonjs",
+  },
+  "references": [
+    {"path": ".."}
+  ]
+}
+```

--- a/docs/esm.md
+++ b/docs/esm.md
@@ -67,7 +67,7 @@ oclif
 {
   ...
   "bin": {
-    "<Your CLI Name>": "./bin/run.mjs"
+    "<Your_CLI_Name>": "./bin/run.mjs"
   },
   ...
 }

--- a/docs/esm.md
+++ b/docs/esm.md
@@ -11,6 +11,7 @@ If you want to write your CLI or plugins using ESM you just need to make a few c
   "compilerOptions": {
     "module": "ES2020",
     "moduleResolution": "node",
+    "composite": true
   },
   "ts-node": {
     "esm": true
@@ -18,7 +19,7 @@ If you want to write your CLI or plugins using ESM you just need to make a few c
 }
 ```
 
-2. Rename `bin/dev` to `bin/dev.js` and replace the contents with the following:
+2. Rename `bin/dev` to `bin/dev.mjs` and replace the contents with the following:
 
 ```javascript
 #!/usr/bin/env ts-node
@@ -48,7 +49,7 @@ oclif
 .catch(oclif.Errors.handle)
 ```
 
-3. Rename `bin/run` to `bin/run.js` and replace the contents with the following:
+3. Rename `bin/run` to `bin/run.mjs` and replace the contents with the following:
 
 ```javascript
 #!/usr/bin/env node
@@ -60,3 +61,13 @@ oclif
 .then(oclif.flush)
 .catch(oclif.Errors.handle)
 ```
+
+4. Update package.json bin in order to use new run.mjs file
+```json
+{
+  ...
+  "bin": {
+    "<Your CLI Name>": "./bin/run.mjs"
+  },
+  ...
+}


### PR DESCRIPTION
I tried the old tutorial, but run into troubles.
First I tried to update package.json to be "type":"module" then oclif was working with esm but then test don't work, because mocha not working with esm after transforming mocha to esm
the oclif/test was to working so I would stay with cjs here

So did the changes I committed and now all works
- running package with node
- linking via npm link
- running the mocha tests

P.S.
Thank you for great lib I'm loving it