### PR TITLE
Improve error outside of commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,9 +145,9 @@ Note: You may need to install the latest `@oclif/core` and `@oclif/errors` for `
 These errors are friendly and won't show a traceback unless debugging is enabled with `DEBUG=*` or `CLI_NAME_DEBUG=1`. If you want to raise errors like this outside of a command, use `@oclif/errors`.
 
 ```typescript
-import {CLIError} from '@oclif/errors'
+import { error } from '@oclif/errors'
 
-throw new CLIError('my friendly error')
+error('my friendly error', { suggestions: 'You can try X' })
 ```
 
 Any error caught by the command of this `CLIError` type will be shown without traceback.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,7 +150,7 @@ import { error } from '@oclif/errors'
 error('my friendly error', { suggestions: 'You can try X' })
 ```
 
-Any error caught by the command of this `CLIError` type will be shown without traceback.
+Any error caught by the command of this `error` type will be shown without traceback.
 
 ### `this.exit(code: number = 0)`
 


### PR DESCRIPTION
- The existing example with CLIError does not support pretty error. Using warn/error directly is more close match to this.error, this.warn in commands