### PR TITLE
fix prompting/inquirer section

### DIFF
--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -62,6 +62,35 @@ export class MyCommand extends Command {
 }
 ```
 
+**NOTE**: inquirer >= v9 is an ESM package. If you aren't using ESM in your CLI/plugin, you should set [`moduleResolution` to `node16`](https://www.typescriptlang.org/tsconfig#moduleResolution) in your tsconfig.json and [import it using `await import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import):
+
+```typescript
+import {Command, Flags} from '@oclif/core'
+
+export class MyCommand extends Command {
+  static flags = {
+    stage: Flags.string({options: ['development', 'staging', 'production']})
+  }
+
+  async run() {
+    const {flags} = await this.parse(MyCommand)
+    let stage = flags.stage
+    if (!stage) {
+      const { default: inquirer } = await import("inquirer")
+      let responses: any = inquirer.prompt([{
+        name: 'stage',
+        message: 'select a stage',
+        type: 'list',
+        choices: [{name: 'development'}, {name: 'staging'}, {name: 'production'}],
+      }])
+      stage = responses.stage
+    }
+    this.log(`the stage is: ${stage}`)
+  }
+}
+```
+
+
 Demo:
 
 ![inquirer demo](/img/inquirer_demo.gif)


### PR DESCRIPTION
Updates prompting/inquirer section to add an example using inquirer v9 (ESM) in a CommonJS CLI/plugin.

Closes: https://github.com/oclif/core/issues/476