### PR TITLE
Correct technical typo

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -11,7 +11,7 @@ import {Command} from '@oclif/core'
 export class HelloCommand extends Command {
   public static enableJsonFlag = true
   public async run(): Promise<{ message: string }> {
-    console.log('hello, world!')
+    this.log('hello, world!')
     return { message: 'hello, world!' }
   }
 }


### PR DESCRIPTION
Your demonstration code would not return the output mentioned, going against the point you are explaining in the previous paragraph.

Using `console.log` would result in the message being returned alongside the JSON output. The correct function to be used in this case is `this.log`.