### PR TITLE
Fix typo in UX guide

### DIFF
--- a/docs/user_experience.md
+++ b/docs/user_experience.md
@@ -3,11 +3,11 @@ title: User Experience
 description: Provided user-experience utilities
 ---
 
-oclif's philosophy is that developers should free to design any user experience that they want for their users. In other words, we try really hard to not make any UX decisions for you.
+oclif's philosophy is that developers should be free to design any user experience they want for their users. In other words, we try really hard to not make any UX decisions for you.
 
-So many times we utilize [hooks](./hooks.md) whenever a user experience is required (e.g. the provided command isn't found). That way you can design the exact experience you want your users to have. In the case of error handling, you're [able to override](./error_handling.md) oclif's default behavior.
+So many times we utilize [hooks](./hooks.md) whenever a user experience is required (e.g. the provided command isn't found). That way, you can design the exact experience you want your users to have. In the case of error handling, you're [able to override](./error_handling.md) oclif's default behavior.
 
-But to make it easy for you, `@oclif/core` exports a [`ux` module](https://github.com/oclif/core/blob/main/src/cli-ux/README.md) that offers several tools you can use to implement your desired user experience.
+But to make it easy for you, `@oclif/core` exports a [`ux` module](https://github.com/oclif/core/blob/main/src/cli-ux/README.md) that offers several tools to implement your desired user experience.
 
 However, due to time constraints we are not able to support this module as well as we would like. For that reason, we **strongly** recommend that you find npm libraries that specialize in the UX components you want to use. Here's a brief list of some of the libraries we like:
 


### PR DESCRIPTION
This is a very tiny fix, but there's an important missing word in the first sentence of this docs page.